### PR TITLE
Update Podfile to use CocoaPods CDN instead of the git source

### DIFF
--- a/BasicCasting/BasicCasting.xcodeproj/project.pbxproj
+++ b/BasicCasting/BasicCasting.xcodeproj/project.pbxproj
@@ -175,12 +175,12 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-BasicCasting/Pods-BasicCasting-frameworks.sh",
 				"${PODS_ROOT}/BitmovinPlayer/BitmovinPlayer/iOS/BitmovinPlayer.framework",
-				"${BUILT_PRODUCTS_DIR}/Protobuf/protobuf.framework",
+				"${BUILT_PRODUCTS_DIR}/Protobuf/Protobuf.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BitmovinPlayer.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/protobuf.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Protobuf.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Podfile
+++ b/Podfile
@@ -1,6 +1,6 @@
 platform :ios, '10.3'
 
-source 'https://github.com/CocoaPods/Specs.git'
+source 'https://cdn.cocoapods.org'
 source 'https://github.com/bitmovin/cocoapod-specs.git'
 
 workspace 'BitmovinPlayerSamples'


### PR DESCRIPTION
The CDN is much faster than the git source, and has been supported since CocoaPods 1.7.2.

More about the CDN here: https://blog.cocoapods.org/CocoaPods-1.7.2/