### PR TITLE
update urlWithCorrelator to fix Simulator crash

### DIFF
--- a/BasicAds/BasicAds/ViewController.swift
+++ b/BasicAds/BasicAds/ViewController.swift
@@ -69,7 +69,11 @@ final class ViewController: UIViewController {
     }
     
     func urlWithCorrelator(adTag: String) -> URL {
-        return URL(string: String(format: "%@%d", adTag, Int(arc4random_uniform(100000))))!
+        var urlString = adTag
+        #if targetEnvironment(simulator)
+            urlString = adTag.addingPercentEncoding( withAllowedCharacters: .urlQueryAllowed )!
+        #endif
+        return URL(string: String(format: "%@%d", urlString, Int(arc4random_uniform(100000))))!
     }
 }
 


### PR DESCRIPTION
Some URLs(Many Freewheel URLs for example) cause a crash on Simulators when trying to unwrap the optional URL- [Fatal error: Unexpectedly found nil while unwrapping an Optional value]. - Sample crashing URL -> "https://2517d.v.fwmrm.net/ad/g/1?nw=151933&prof=151933:crackle_ios_mobile_live&vcid=&caid=2520725&csid=crackle_iphone_us/&resp=vmap1&crtp=vast3ap&afid=37040698&pvrn=96042&vprn=96042&flag=+aeti+emcr+qtcb+slcb+sltp+exvt+fbad+ssus+dtrd&metr=7;comscore_platform=ios&comscore_device=64-bit Simulator&_fw_did=:&is_lat=&ifa_type=&_fw_vcid2=151933:&cav=6.5.0.7&_fw_coppa=&player_width=375.0&player_height=812.0&nielsen_app_id=PFDF102BF-8FB9-B8EF-E040-070AAD315556&nielsen_device_group=PHN&nielsen_platform=MB&_fw_fss=_fw_search"

## Problem
<!-- Describe the problem briefly -->

## Fix
<!-- Describe how you fixed it -->

## Checklist (for PR submitters and reviewers)
- Correct player version
- No SwiftLint errors / warnings (or argue coherent why a warning is not adressed)
- **Please make sure that no player license key and development team is commited resp. copied to the public sample repo after merge**
<!-- For every PR that gets merged although it violates the checklist, the PR submitter and all reviewers buy a round of drinks for the whole player team! -->
